### PR TITLE
docs: explain intentOracle extension for cross-chain deposits

### DIFF
--- a/apps/docs/docs/pages/concepts/cross-chain.mdx
+++ b/apps/docs/docs/pages/concepts/cross-chain.mdx
@@ -126,6 +126,77 @@ Two oracles ensure secure cross-chain settlement:
 | **fillOracle** | Dest → Origin | Proves the solver filled the intent |
 | **intentOracle** | Origin → Dest | Proves the intent is legitimate (deposits only) |
 
+## Why intentOracle is Required (Shinobi Extension)
+
+:::warning[Critical Security]
+This is Shinobi's key extension to the standard OIF. Without it, privacy pools are vulnerable to money laundering attacks.
+:::
+
+### The Problem with Optimistic Settlement
+
+Standard cross-chain intent systems (like ERC-7683) use **optimistic settlement**:
+
+```
+Standard Flow (ERC-7683):
+1. User signs intent (off-chain)
+2. Solver fills on destination (fronts capital)
+3. Solver claims reimbursement on origin
+```
+
+The security assumption: **Solvers are economically rational** — they won't fill intents they can't profitably settle.
+
+### Why Optimistic Fails for Privacy Pools
+
+In privacy pools, an attacker can control **both the "user" and the solver**:
+
+```
+Attack:
+1. Attacker has illicit funds in address A
+2. Attacker controls clean address B
+3. Attacker signs intent with B as depositor (but B has no funds)
+4. Attacker (as solver) fills with A's illicit funds
+5. Deposit attributed to B (clean) → passes ASP
+6. Settlement fails (B never deposited) — attacker doesn't care
+7. Attacker withdraws "clean" funds via ZK proof
+
+Result: FREE LAUNDERING
+```
+
+The attacker doesn't lose funds — they just moved illicit funds through the pool with clean attribution.
+
+### Shinobi's Solution: Input-First with Intent Proof
+
+Shinobi requires **verified deposits** before fills are accepted:
+
+```
+Shinobi Flow:
+1. User deposits on origin → funds escrowed (user = msg.sender)
+2. Intent oracle proves deposit to destination
+3. Fill ONLY accepted with valid intent proof
+4. Depositor address cryptographically bound to fund provider
+```
+
+```solidity
+// ShinobiDepositOutputSettler.fill()
+if (!IInputOracle(intentOracle).isProven(orderId))
+    revert IntentNotProven();  // Blocks fill without real deposit
+```
+
+This ensures the **depositor address equals the fund provider** — not just someone who signed an authorization.
+
+### Why This Can't Use Standard ERC-7683
+
+ERC-7683's optimistic model is **fundamentally incompatible** with privacy pool deposits:
+
+| Aspect | ERC-7683 (Optimistic) | Shinobi (Verified) |
+|--------|----------------------|-------------------|
+| Security model | Solver economic rationality | Cryptographic proof |
+| Assumption | Solver ≠ User | Attacker may be both |
+| Fill validation | None (optimistic) | Intent oracle required |
+| Compatible with | Standard solver marketplaces | Shinobi-aware solvers |
+
+The trade-off: Shinobi cannot use generic ERC-7683 solver marketplaces for deposits, but gains critical security against money laundering.
+
 ## Refund Mechanism
 
 If a cross-chain withdrawal intent expires without being filled:

--- a/apps/docs/docs/pages/concepts/threat-model.mdx
+++ b/apps/docs/docs/pages/concepts/threat-model.mdx
@@ -115,6 +115,51 @@ This document describes the adversaries Shinobi Cash considers, the attacks they
 
 **Outcome:** Context binding (hash of withdrawal data + scope) makes proofs non-replayable. Same proof cannot be used for different withdrawal.
 
+### Scenario 5: User-Solver Money Laundering (Cross-Chain Deposits)
+
+**Attack:** Attacker controls both a "clean" address and illicit funds, and operates as a solver:
+
+```
+1. Attacker has illicit ETH in address A (would fail ASP)
+2. Attacker controls clean address B (no history)
+3. Attacker signs a deposit intent with B as depositor
+4. Attacker (as solver) fills the intent using A's illicit funds
+5. Deposit attributed to B → passes ASP compliance
+6. Attacker withdraws "clean" funds later via ZK proof
+```
+
+**Why this matters:** This is **free laundering** — the attacker doesn't lose funds, they just move illicit funds through the pool with clean attribution.
+
+**Why standard cross-chain solutions fail:**
+
+Standard intent systems (like ERC-7683) use **optimistic settlement**:
+- Solver fills first, gets reimbursed later
+- Security relies on solver economic rationality
+- Solvers won't fill orders they can't profitably settle
+
+But when **attacker = user = solver**:
+- Attacker doesn't care about settlement profit
+- Attacker's goal is laundering, not profit
+- "Failed settlement" is irrelevant — deposit already happened
+
+**Mitigation (Shinobi's intentOracle Extension):**
+
+Shinobi Cash extends the standard OIF with **mandatory intent proof validation** for deposits:
+
+```solidity
+// ShinobiDepositOutputSettler.fill()
+if (!IInputOracle(intentOracle).isProven(orderId))
+    revert IntentNotProven();
+```
+
+This ensures:
+1. User must **actually deposit** funds on origin chain (not just sign)
+2. Intent oracle proves the deposit happened with user's funds
+3. Fill is **blocked** until proof exists
+4. Attacker cannot fill with illicit funds without real deposit from clean address
+
+**Result:** Attack blocked. Depositor address is cryptographically bound to the fund provider.
+
 ## What Shinobi Cash Does NOT Protect Against
 
 - **Compromised wallet** — If your private key is stolen, attacker can sign withdrawals

--- a/apps/docs/docs/pages/contracts/settlers.mdx
+++ b/apps/docs/docs/pages/contracts/settlers.mdx
@@ -152,8 +152,40 @@ function fill(ShinobiIntent calldata intent) external payable nonReentrant {
 }
 ```
 
-**Why intentOracle is required:**
-Without this, an attacker could create fake intents claiming any depositor address. The oracle proves the intent originated from a legitimate user on the origin chain.
+### Why intentOracle is Required
+
+:::warning[Critical Security]
+This is Shinobi's key extension to standard OIF. Without it, privacy pools are vulnerable to money laundering.
+:::
+
+**The attack without intentOracle:**
+
+Standard cross-chain systems use **optimistic settlement** — solvers fill first, get reimbursed later. Security relies on solvers being economically rational.
+
+But when **attacker = user = solver**:
+```
+1. Attacker signs intent with clean address B (no deposit)
+2. Attacker (as solver) fills with illicit funds from address A
+3. Deposit attributed to B → passes ASP compliance
+4. Settlement fails (B never deposited) — attacker doesn't care
+5. Attacker withdraws "clean" funds via ZK proof
+Result: FREE LAUNDERING
+```
+
+**Why optimistic fails for privacy pools:**
+- Normal swaps: Solver wants profit, won't fill unprofitable orders
+- Privacy pools: Attacker wants laundering, profit is irrelevant
+- The economic disincentive doesn't apply
+
+**Shinobi's solution:**
+
+The intentOracle proves the intent was created with **actual escrowed funds** on the origin chain:
+- User must deposit (not just sign)
+- `intent.user = msg.sender` at deposit time
+- Oracle proves this to destination
+- Fill blocked without proof
+
+This ensures: **depositor address = fund provider** (cryptographically enforced)
 
 ## ShinobiWithdrawalOutputSettler
 


### PR DESCRIPTION
Document why Shinobi extends OIF with mandatory intent proof validation:
- Add Scenario 5 (user-solver money laundering) to threat model
- Explain why ERC-7683 optimistic model fails for privacy pools
- Detail the attack: attacker=user=solver enables free laundering
- Document Shinobi's solution